### PR TITLE
Add shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
 
       <section>
         <button data-difficulty="easy">
+          <span class="shortcut">a</span>
           <b>Easy</b>
           <div>
             <span class="food"><b></b> <i data-lucide="beef" class="icon red"></i></span>
@@ -43,6 +44,7 @@
           </div>
         </button>
         <button data-difficulty="medium">
+          <span class="shortcut">s</span>
           <b>Medium</b>
           <div>
             <span class="food"><b></b> <i data-lucide="beef" class="icon red"></i></span>
@@ -51,6 +53,7 @@
           </div>
         </button>
         <button data-difficulty="hard">
+          <span class="shortcut">d</span>
           <b>Hard</b>
           <div>
             No resources <i data-lucide="circle-slash-2" class="icon red"></i>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
   <meta name="description"
     content="Can you survive the apocalypse? Society Fail is a post-apocalyptic incremental game where you must scavenge for resources, fight off mutants, and navigate a world where civilization has fallen apart.">
   <link rel="stylesheet" href="stylesheets/core.css">
+  <link rel="stylesheet" href="stylesheets/modal.css">
+  <link rel="stylesheet" href="stylesheets/shortcuts.css">
 
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
@@ -87,6 +89,10 @@
           <span id="time">Day 1, Hour 1</span>
         </div>
         <div class="button-container">
+          <button id="shortcuts-help">
+            <span class="shortcut">h</span>
+            <i data-lucide="keyboard" class="icon"></i>
+          </button>
           <button id="pause-game"><i data-lucide="pause" class="icon"></i></button>
           <button id="reset-game"><i data-lucide="rotate-ccw" class="icon"></i></button>
         </div>

--- a/index.html
+++ b/index.html
@@ -101,14 +101,17 @@
 
     <section id="actions-module">
       <button id="gatherFoodBtn" class="action-button">
+        <span class="shortcut">q</span>
         <i data-lucide="beef" class="icon dark-yellow"></i>
         <span>Gather Food</span>
       </button>
       <button id="collectWaterBtn" class="action-button">
+        <span class="shortcut">w</span>
         <i data-lucide="droplet" class="icon blue"></i>
         <span>Collect Water</span>
       </button>
       <button id="chopWoodBtn" class="action-button">
+        <span class="shortcut">e</span>
         <i data-lucide="tree-pine" class="icon green"></i>
         <span>Chop Wood</span>
       </button>

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -6,6 +6,7 @@
 
 import { createLucideIcons } from './utils.js';
 import { initializeGame } from './game.js';
+import { initializeShortcuts } from './shortcuts.js';
 
 /**
  * Event listener for DOMContentLoaded event.
@@ -20,6 +21,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Initialize the game
   initializeGame();
+
+  // Initialize shortcuts
+  initializeShortcuts();
 
   // Log successful initialization
   console.log('Game initialization complete');

--- a/javascript/core.js
+++ b/javascript/core.js
@@ -7,6 +7,7 @@
 import { createLucideIcons } from './utils.js';
 import { initializeGame } from './game.js';
 import { initializeShortcuts } from './shortcuts.js';
+import { initializeShortcutsModal } from './shortcuts-modal.js';
 
 /**
  * Event listener for DOMContentLoaded event.
@@ -22,8 +23,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // Initialize the game
   initializeGame();
 
-  // Initialize shortcuts
+  // Initialize shortcuts and modal
   initializeShortcuts();
+  initializeShortcutsModal();
 
   // Log successful initialization
   console.log('Game initialization complete');

--- a/javascript/party.js
+++ b/javascript/party.js
@@ -224,7 +224,7 @@ export function updatePartyDisplay() {
           Drink <span>[3 <i data-lucide="droplet" class="icon blue"></i>]</span>
         </button>
         <button data-action="sleep" data-person="${index}" ${(person.isDead || isBusy || isResting) ? 'disabled' : ''}>
-          ${index === 0 ? '<span class="shortcut">p</span>' : index === 1 ? '<span class="shortcut">l</span>' : '<span class="shortcut">.</span>'}
+          ${index === 0 ? '<span class="shortcut">o</span>' : index === 1 ? '<span class="shortcut">l</span>' : '<span class="shortcut">.</span>'}
           <i data-lucide="bed-single" class="icon magenta"></i> Rest
         </button>
       </div>

--- a/javascript/party.js
+++ b/javascript/party.js
@@ -215,9 +215,18 @@ export function updatePartyDisplay() {
         </table>
       </div>
       <div class="person-actions">
-        <button data-action="eat" data-person="${index}" ${(person.isDead || isBusy || isResting || gameState.food < 5) ? 'disabled' : ''}>Eat <span>[5 <i data-lucide="beef" class="icon dark-yellow"></i>]</span></button>
-        <button data-action="drink" data-person="${index}" ${(person.isDead || isBusy || isResting || gameState.water < 3) ? 'disabled' : ''}> Drink <span>[3 <i data-lucide="droplet" class="icon blue"></i>]</span></button>
-        <button data-action="sleep" data-person="${index}" ${(person.isDead || isBusy || isResting) ? 'disabled' : ''}><i data-lucide="bed-single" class="icon magenta"></i> Rest</button>
+        <button data-action="eat" data-person="${index}" ${(person.isDead || isBusy || isResting || gameState.food < 5) ? 'disabled' : ''}>
+          ${index === 0 ? '<span class="shortcut">u</span>' : index === 1 ? '<span class="shortcut">j</span>' : '<span class="shortcut">m</span>'}
+          Eat <span>[5 <i data-lucide="beef" class="icon dark-yellow"></i>]</span>
+        </button>
+        <button data-action="drink" data-person="${index}" ${(person.isDead || isBusy || isResting || gameState.water < 3) ? 'disabled' : ''}>
+          ${index === 0 ? '<span class="shortcut">i</span>' : index === 1 ? '<span class="shortcut">k</span>' : '<span class="shortcut">,</span>'}
+          Drink <span>[3 <i data-lucide="droplet" class="icon blue"></i>]</span>
+        </button>
+        <button data-action="sleep" data-person="${index}" ${(person.isDead || isBusy || isResting) ? 'disabled' : ''}>
+          ${index === 0 ? '<span class="shortcut">p</span>' : index === 1 ? '<span class="shortcut">l</span>' : '<span class="shortcut">.</span>'}
+          <i data-lucide="bed-single" class="icon magenta"></i> Rest
+        </button>
       </div>
     `;
     partyContainer.appendChild(personElement);

--- a/javascript/shortcuts-modal.js
+++ b/javascript/shortcuts-modal.js
@@ -1,0 +1,72 @@
+/**
+ * Manages the shortcuts help modal and shortcuts visibility toggle
+ */
+
+// Track if shortcuts are visible
+let shortcutsVisible = true;
+
+// Create and append modal HTML
+const modalHTML = `
+<div id="shortcuts-modal" class="modal hidden">
+  <div class="modal-content">
+    <header>
+      <h2><i data-lucide="keyboard" class="icon"></i> Keyboard Shortcuts</h2>
+      <button class="close-modal"><i data-lucide="x" class="icon"></i></button>
+    </header>
+    
+    <div class="shortcuts-toggle">
+      <label>
+        <input type="checkbox" id="shortcuts-toggle" checked>
+        Show shortcuts in game
+      </label>
+    </div>
+
+    <div class="shortcuts-list">
+      <h3>Game Controls</h3>
+      <ul>
+        <li><kbd>H</kbd> Toggle shortcuts help</li>
+      </ul>
+      
+      <h3>Difficulty Selection</h3>
+      <ul>
+        <li><kbd>A</kbd> Select Easy mode</li>
+        <li><kbd>S</kbd> Select Medium mode</li>
+        <li><kbd>D</kbd> Select Hard mode</li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+export function initializeShortcutsModal() {
+  // Append modal to body
+  document.body.insertAdjacentHTML('beforeend', modalHTML);
+  
+  const modal = document.getElementById('shortcuts-modal');
+  const closeBtn = modal.querySelector('.close-modal');
+  const toggleCheckbox = document.getElementById('shortcuts-toggle');
+  const shortcutsBtn = document.getElementById('shortcuts-help');
+
+  // Show modal when shortcuts button is clicked
+  shortcutsBtn.addEventListener('click', () => {
+    modal.classList.remove('hidden');
+  });
+
+  // Close modal when close button is clicked
+  closeBtn.addEventListener('click', () => {
+    modal.classList.add('hidden');
+  });
+
+  // Close modal when clicking outside
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) {
+      modal.classList.add('hidden');
+    }
+  });
+
+  // Handle shortcuts visibility toggle
+  toggleCheckbox.addEventListener('change', () => {
+    shortcutsVisible = toggleCheckbox.checked;
+    document.body.classList.toggle('hide-shortcuts', !shortcutsVisible);
+  });
+} 

--- a/javascript/shortcuts-modal.js
+++ b/javascript/shortcuts-modal.js
@@ -51,7 +51,7 @@ const modalHTML = `
           <td><kbd>,</kbd> Drink</td>
         </tr>
         <tr>
-          <td><kbd>P</kbd> Rest</td>
+          <td><kbd>O</kbd> Rest</td>
           <td><kbd>L</kbd> Rest</td>
           <td><kbd>.</kbd> Rest</td>
         </tr>

--- a/javascript/shortcuts-modal.js
+++ b/javascript/shortcuts-modal.js
@@ -25,6 +25,9 @@ const modalHTML = `
       <h3>Game Controls</h3>
       <ul>
         <li><kbd>H</kbd> Toggle shortcuts help</li>
+        <li><kbd>Q</kbd> Gather Food</li>
+        <li><kbd>W</kbd> Collect Water</li>
+        <li><kbd>E</kbd> Chop Wood</li>
       </ul>
       
       <h3>Difficulty Selection</h3>

--- a/javascript/shortcuts-modal.js
+++ b/javascript/shortcuts-modal.js
@@ -30,6 +30,27 @@ const modalHTML = `
         <li><kbd>E</kbd> Chop Wood</li>
       </ul>
       
+      <h3>Party Member 1</h3>
+      <ul>
+        <li><kbd>U</kbd> Eat</li>
+        <li><kbd>I</kbd> Drink</li>
+        <li><kbd>P</kbd> Rest</li>
+      </ul>
+
+      <h3>Party Member 2</h3>
+      <ul>
+        <li><kbd>J</kbd> Eat</li>
+        <li><kbd>K</kbd> Drink</li>
+        <li><kbd>L</kbd> Rest</li>
+      </ul>
+
+      <h3>Party Member 3</h3>
+      <ul>
+        <li><kbd>M</kbd> Eat</li>
+        <li><kbd>,</kbd> Drink</li>
+        <li><kbd>.</kbd> Rest</li>
+      </ul>
+      
       <h3>Difficulty Selection</h3>
       <ul>
         <li><kbd>A</kbd> Select Easy mode</li>

--- a/javascript/shortcuts-modal.js
+++ b/javascript/shortcuts-modal.js
@@ -2,8 +2,8 @@
  * Manages the shortcuts help modal and shortcuts visibility toggle
  */
 
-// Track if shortcuts are visible
-let shortcutsVisible = true;
+// Track if shortcuts are visible - default to false on mobile
+let shortcutsVisible = window.innerWidth > 800;
 
 // Create and append modal HTML
 const modalHTML = `
@@ -16,47 +16,46 @@ const modalHTML = `
     
     <div class="shortcuts-toggle">
       <label>
-        <input type="checkbox" id="shortcuts-toggle" checked>
+        <input type="checkbox" id="shortcuts-toggle" ${window.innerWidth > 800 ? 'checked' : ''}>
         Show shortcuts in game
       </label>
     </div>
 
     <div class="shortcuts-list">
-      <h3>Game Controls</h3>
       <ul>
         <li><kbd>H</kbd> Toggle shortcuts help</li>
+      </ul>
+
+      <h3>Game Controls</h3>
+      <ul>
         <li><kbd>Q</kbd> Gather Food</li>
         <li><kbd>W</kbd> Collect Water</li>
         <li><kbd>E</kbd> Chop Wood</li>
       </ul>
       
-      <h3>Party Member 1</h3>
-      <ul>
-        <li><kbd>U</kbd> Eat</li>
-        <li><kbd>I</kbd> Drink</li>
-        <li><kbd>P</kbd> Rest</li>
-      </ul>
-
-      <h3>Party Member 2</h3>
-      <ul>
-        <li><kbd>J</kbd> Eat</li>
-        <li><kbd>K</kbd> Drink</li>
-        <li><kbd>L</kbd> Rest</li>
-      </ul>
-
-      <h3>Party Member 3</h3>
-      <ul>
-        <li><kbd>M</kbd> Eat</li>
-        <li><kbd>,</kbd> Drink</li>
-        <li><kbd>.</kbd> Rest</li>
-      </ul>
-      
-      <h3>Difficulty Selection</h3>
-      <ul>
-        <li><kbd>A</kbd> Select Easy mode</li>
-        <li><kbd>S</kbd> Select Medium mode</li>
-        <li><kbd>D</kbd> Select Hard mode</li>
-      </ul>
+      <h3>Party Members</h3>
+      <table>
+        <tr>
+          <th>Member 1</th>
+          <th>Member 2</th>
+          <th>Member 3</th>
+        </tr>
+        <tr>
+          <td><kbd>U</kbd> Eat</td>
+          <td><kbd>J</kbd> Eat</td>
+          <td><kbd>M</kbd> Eat</td>
+        </tr>
+        <tr>
+          <td><kbd>I</kbd> Drink</td>
+          <td><kbd>K</kbd> Drink</td>
+          <td><kbd>,</kbd> Drink</td>
+        </tr>
+        <tr>
+          <td><kbd>P</kbd> Rest</td>
+          <td><kbd>L</kbd> Rest</td>
+          <td><kbd>.</kbd> Rest</td>
+        </tr>
+      </table>
     </div>
   </div>
 </div>
@@ -65,6 +64,9 @@ const modalHTML = `
 export function initializeShortcutsModal() {
   // Append modal to body
   document.body.insertAdjacentHTML('beforeend', modalHTML);
+  
+  // Set initial state for shortcuts visibility
+  document.body.classList.toggle('hide-shortcuts', !shortcutsVisible);
   
   const modal = document.getElementById('shortcuts-modal');
   const closeBtn = modal.querySelector('.close-modal');

--- a/javascript/shortcuts.js
+++ b/javascript/shortcuts.js
@@ -1,10 +1,13 @@
 /**
- * Handles keyboard shortcuts for selecting game difficulty
+ * Handles keyboard shortcuts for selecting game difficulty and game actions
  * Shortcuts:
  * - 'a' for Easy
  * - 's' for Medium
  * - 'd' for Hard
  * - 'h' to open shortcuts help
+ * - 'q' to gather food
+ * - 'w' to collect water
+ * - 'e' to chop wood
  */
 export function initializeShortcuts() {
   // Map keys to difficulty levels
@@ -12,6 +15,13 @@ export function initializeShortcuts() {
     'a': 'easy',
     's': 'medium',
     'd': 'hard'
+  };
+
+  // Map keys to action buttons
+  const ACTION_SHORTCUTS = {
+    'q': 'gatherFoodBtn',
+    'w': 'collectWaterBtn',
+    'e': 'chopWoodBtn'
   };
 
   // Event listener for keydown events
@@ -27,6 +37,18 @@ export function initializeShortcuts() {
         modal.classList.add('hidden');
       } else if (shortcutsBtn) {
         shortcutsBtn.click();
+      }
+      return;
+    }
+
+    // Handle action shortcuts if we're on the game screen
+    if (ACTION_SHORTCUTS[key]) {
+      const gameScreen = document.getElementById('game_screen');
+      if (!gameScreen?.classList.contains('hidden')) {
+        const button = document.getElementById(ACTION_SHORTCUTS[key]);
+        if (button) {
+          button.click();
+        }
       }
       return;
     }

--- a/javascript/shortcuts.js
+++ b/javascript/shortcuts.js
@@ -8,6 +8,9 @@
  * - 'q' to gather food
  * - 'w' to collect water
  * - 'e' to chop wood
+ * - Party member 1: 'u'=eat, 'i'=drink, 'p'=sleep
+ * - Party member 2: 'j'=eat, 'k'=drink, 'l'=sleep
+ * - Party member 3: 'm'=eat, ','=drink, '.'=sleep
  */
 export function initializeShortcuts() {
   // Map keys to difficulty levels
@@ -24,6 +27,19 @@ export function initializeShortcuts() {
     'e': 'chopWoodBtn'
   };
 
+  // Map keys to party member actions
+  const PARTY_SHORTCUTS = {
+    'u': { index: 0, action: 'eat' },
+    'i': { index: 0, action: 'drink' },
+    'p': { index: 0, action: 'sleep' },
+    'j': { index: 1, action: 'eat' },
+    'k': { index: 1, action: 'drink' },
+    'l': { index: 1, action: 'sleep' },
+    'm': { index: 2, action: 'eat' },
+    ',': { index: 2, action: 'drink' },
+    '.': { index: 2, action: 'sleep' }
+  };
+
   // Event listener for keydown events
   document.addEventListener('keydown', (event) => {
     const key = event.key.toLowerCase();
@@ -37,6 +53,19 @@ export function initializeShortcuts() {
         modal.classList.add('hidden');
       } else if (shortcutsBtn) {
         shortcutsBtn.click();
+      }
+      return;
+    }
+
+    // Handle party member shortcuts if we're on the game screen
+    if (PARTY_SHORTCUTS[key]) {
+      const gameScreen = document.getElementById('game_screen');
+      if (!gameScreen?.classList.contains('hidden')) {
+        const { index, action } = PARTY_SHORTCUTS[key];
+        const button = document.querySelector(`button[data-action="${action}"][data-person="${index}"]:not([disabled])`);
+        if (button) {
+          button.click();
+        }
       }
       return;
     }

--- a/javascript/shortcuts.js
+++ b/javascript/shortcuts.js
@@ -4,6 +4,7 @@
  * - 'a' for Easy
  * - 's' for Medium
  * - 'd' for Hard
+ * - 'h' to open shortcuts help
  */
 export function initializeShortcuts() {
   // Map keys to difficulty levels
@@ -15,11 +16,24 @@ export function initializeShortcuts() {
 
   // Event listener for keydown events
   document.addEventListener('keydown', (event) => {
-    // Only process shortcuts if we're on the start screen
+    const key = event.key.toLowerCase();
+
+    // Handle help shortcut (works on any screen)
+    if (key === 'h') {
+      const modal = document.getElementById('shortcuts-modal');
+      const shortcutsBtn = document.getElementById('shortcuts-help');
+      
+      if (modal && !modal.classList.contains('hidden')) {
+        modal.classList.add('hidden');
+      } else if (shortcutsBtn) {
+        shortcutsBtn.click();
+      }
+      return;
+    }
+
+    // Only process difficulty shortcuts if we're on the start screen
     const startScreen = document.getElementById('game_start_screen');
     if (startScreen.classList.contains('hidden')) return;
-
-    const key = event.key.toLowerCase();
     
     // Check if the pressed key matches any of our shortcuts
     if (DIFFICULTY_SHORTCUTS[key]) {

--- a/javascript/shortcuts.js
+++ b/javascript/shortcuts.js
@@ -33,7 +33,7 @@ export function initializeShortcuts() {
 
     // Only process difficulty shortcuts if we're on the start screen
     const startScreen = document.getElementById('game_start_screen');
-    if (startScreen.classList.contains('hidden')) return;
+    if (startScreen?.classList.contains('hidden')) return;
     
     // Check if the pressed key matches any of our shortcuts
     if (DIFFICULTY_SHORTCUTS[key]) {

--- a/javascript/shortcuts.js
+++ b/javascript/shortcuts.js
@@ -8,7 +8,7 @@
  * - 'q' to gather food
  * - 'w' to collect water
  * - 'e' to chop wood
- * - Party member 1: 'u'=eat, 'i'=drink, 'p'=sleep
+ * - Party member 1: 'u'=eat, 'i'=drink, 'o'=sleep
  * - Party member 2: 'j'=eat, 'k'=drink, 'l'=sleep
  * - Party member 3: 'm'=eat, ','=drink, '.'=sleep
  */
@@ -31,7 +31,7 @@ export function initializeShortcuts() {
   const PARTY_SHORTCUTS = {
     'u': { index: 0, action: 'eat' },
     'i': { index: 0, action: 'drink' },
-    'p': { index: 0, action: 'sleep' },
+    'o': { index: 0, action: 'sleep' },
     'j': { index: 1, action: 'eat' },
     'k': { index: 1, action: 'drink' },
     'l': { index: 1, action: 'sleep' },

--- a/javascript/shortcuts.js
+++ b/javascript/shortcuts.js
@@ -1,0 +1,33 @@
+/**
+ * Handles keyboard shortcuts for selecting game difficulty
+ * Shortcuts:
+ * - 'a' for Easy
+ * - 's' for Medium
+ * - 'd' for Hard
+ */
+export function initializeShortcuts() {
+  // Map keys to difficulty levels
+  const DIFFICULTY_SHORTCUTS = {
+    'a': 'easy',
+    's': 'medium',
+    'd': 'hard'
+  };
+
+  // Event listener for keydown events
+  document.addEventListener('keydown', (event) => {
+    // Only process shortcuts if we're on the start screen
+    const startScreen = document.getElementById('game_start_screen');
+    if (startScreen.classList.contains('hidden')) return;
+
+    const key = event.key.toLowerCase();
+    
+    // Check if the pressed key matches any of our shortcuts
+    if (DIFFICULTY_SHORTCUTS[key]) {
+      // Find and click the corresponding difficulty button
+      const button = document.querySelector(`button[data-difficulty="${DIFFICULTY_SHORTCUTS[key]}"]`);
+      if (button) {
+        button.click();
+      }
+    }
+  });
+} 

--- a/stylesheets/modal.css
+++ b/stylesheets/modal.css
@@ -1,0 +1,100 @@
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+
+  &.hidden {
+    display: none;
+  }
+
+  .modal-content {
+    background: var(--background-color);
+    border: var(--border-thickness) solid var(--text-color);
+    max-width: 500px;
+    width: 90%;
+    
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem;
+      border-bottom: var(--border-thickness) solid var(--text-color);
+
+      h2 {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .close-modal {
+        padding: 0.5rem;
+        border: none;
+        background: none;
+        cursor: pointer;
+      }
+    }
+
+    .shortcuts-toggle {
+      padding: 1rem;
+      border-bottom: var(--border-thickness) solid var(--text-color);
+
+      label {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+    }
+
+    .shortcuts-list {
+      padding: 1rem;
+
+      h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
+      }
+
+      .empty-state {
+        color: var(--text-color-muted);
+        font-style: italic;
+      }
+
+      ul {
+        list-style: none;
+        padding: 0;
+        margin: 0 0 1.5rem;
+
+        li {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          margin-bottom: 0.5rem;
+        }
+      }
+
+      kbd {
+        background: var(--text-color);
+        color: var(--background-color);
+        padding: 0.2rem 0.4rem;
+        border-radius: 3px;
+        font-size: 0.9em;
+        min-width: 1.5em;
+        text-align: center;
+        display: inline-block;
+      }
+    }
+  }
+}
+
+/* Hide shortcuts when toggled off */
+body.hide-shortcuts .shortcut {
+  display: none !important;
+} 

--- a/stylesheets/modal.css
+++ b/stylesheets/modal.css
@@ -19,6 +19,9 @@
     border: var(--border-thickness) solid var(--text-color);
     max-width: 500px;
     width: 90%;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
     
     header {
       display: flex;
@@ -26,6 +29,7 @@
       justify-content: space-between;
       padding: 1rem;
       border-bottom: var(--border-thickness) solid var(--text-color);
+      flex-shrink: 0;
 
       h2 {
         display: flex;
@@ -46,6 +50,7 @@
     .shortcuts-toggle {
       padding: 1rem;
       border-bottom: var(--border-thickness) solid var(--text-color);
+      flex-shrink: 0;
 
       label {
         display: flex;
@@ -56,6 +61,7 @@
 
     .shortcuts-list {
       padding: 1rem;
+      overflow-y: auto;
 
       h3 {
         margin: 0 0 0.5rem;
@@ -65,6 +71,23 @@
       .empty-state {
         color: var(--text-color-muted);
         font-style: italic;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 0 0 1.5rem;
+
+        th, td {
+          text-align: left;
+          padding: 0.5rem;
+          width: 33.33%;
+        }
+
+        th {
+          font-weight: bold;
+          border-bottom: var(--border-thickness) solid var(--text-color);
+        }
       }
 
       ul {

--- a/stylesheets/shortcuts.css
+++ b/stylesheets/shortcuts.css
@@ -20,7 +20,8 @@
 
 /* Button shortcuts */
 .button-container button,
-.action-button {
+.action-button,
+.person-actions button {
   position: relative;
 
   .shortcut {

--- a/stylesheets/shortcuts.css
+++ b/stylesheets/shortcuts.css
@@ -18,8 +18,9 @@
   font-size: 0.8rem;
 }
 
-/* Header button shortcuts */
-.button-container button {
+/* Button shortcuts */
+.button-container button,
+.action-button {
   position: relative;
 
   .shortcut {

--- a/stylesheets/shortcuts.css
+++ b/stylesheets/shortcuts.css
@@ -1,0 +1,45 @@
+/* Shortcut indicators */
+.shortcut {
+  position: absolute;
+  background: var(--text-color);
+  color: var(--background-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+}
+
+/* Difficulty selection shortcuts */
+#game_start_screen section button .shortcut {
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: 0.8rem;
+}
+
+/* Header button shortcuts */
+.button-container button {
+  position: relative;
+
+  .shortcut {
+    top: 0.2rem;
+    right: 0.2rem;
+    width: 1.2rem;
+    height: 1.2rem;
+    font-size: 0.7rem;
+  }
+}
+
+/* Mobile view adjustments */
+@media (max-width: 100ch) {
+  #game_start_screen section button .shortcut {
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}
+
+/* Hide shortcuts when toggled off */
+body.hide-shortcuts .shortcut {
+  display: none !important;
+} 

--- a/stylesheets/start.css
+++ b/stylesheets/start.css
@@ -58,21 +58,6 @@
       border-right: var(--border-thickness) solid var(--text-color);
       position: relative;
 
-      .shortcut {
-        position: absolute;
-        top: 0.5rem;
-        right: 0.5rem;
-        background: var(--text-color);
-        color: var(--background-color);
-        width: 1.5rem;
-        height: 1.5rem;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 0.8rem;
-        text-transform: uppercase;
-      }
-
       &:last-child {
         border-right: 0;
       }
@@ -131,11 +116,6 @@
         border-right: none;
         border-bottom: var(--border-thickness) solid var(--text-color);
         width: 100%;
-
-        .shortcut {
-          top: 50%;
-          transform: translateY(-50%);
-        }
 
         &:last-child {
           border-bottom: none;

--- a/stylesheets/start.css
+++ b/stylesheets/start.css
@@ -56,6 +56,22 @@
       margin: 0;
       padding: 1rem;
       border-right: var(--border-thickness) solid var(--text-color);
+      position: relative;
+
+      .shortcut {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        background: var(--text-color);
+        color: var(--background-color);
+        width: 1.5rem;
+        height: 1.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+      }
 
       &:last-child {
         border-right: 0;
@@ -115,6 +131,11 @@
         border-right: none;
         border-bottom: var(--border-thickness) solid var(--text-color);
         width: 100%;
+
+        .shortcut {
+          top: 50%;
+          transform: translateY(-50%);
+        }
 
         &:last-child {
           border-bottom: none;


### PR DESCRIPTION
This PR adds shorcuts to some of the actions in the game. I've tried to keep a similar look to it.

They're shown by default on desktop, but hidden in mobile. Cursor decided 800px was the threshold for mobile. The shortcuts can also be hidden unchecking the checkbox in the modal.

> [!NOTE]
> This was mostly vibe-coded, so there might be a few things that could be improved, like reusing existing code, not using a `dialog` for the modal, or similar.

I think the code came up quite decently, and it's a great compromise for time spent vs code quality.

## Screenshots
Some screenshots of the changes.

### Home page difficulty level shortcuts
<img width="1624" alt="Screenshot 2025-02-28 at 22 37 24" src="https://github.com/user-attachments/assets/32f3a782-fdbf-41ce-bf0e-860f31df7a62" />

### Game view
<img width="1624" alt="Screenshot 2025-02-28 at 22 37 56" src="https://github.com/user-attachments/assets/2d8aa358-12df-4694-a267-44c72883c065" />

You can probably notice I've added a new button on the header, which opens a modal with the shortcuts added.

### New button and modal
<img width="491" alt="image" src="https://github.com/user-attachments/assets/1ca8114e-e1fe-42fb-b419-52b2cd130317" />
<img width="1624" alt="Screenshot 2025-02-28 at 22 41 09" src="https://github.com/user-attachments/assets/891d8f2d-2e8f-4c92-8f8a-59cacdd25f7a" />
